### PR TITLE
Added C++ example code.

### DIFF
--- a/sdk-api-src/content/wingdi/nf-wingdi-getdevicegammaramp.md
+++ b/sdk-api-src/content/wingdi/nf-wingdi-getdevicegammaramp.md
@@ -74,6 +74,17 @@ If this function succeeds, the return value is <b>TRUE</b>.
 
 If this function fails, the return value is <b>FALSE</b>.
 
+## -example
+
+### C++
+
+```
+WORD gArray[3][256];
+GetDeviceGammaRamp(handle, gArray);  
+//handle is the device context. See GetDC for more details.
+//gArray will hold the gamma array values in a 2-D array
+```
+
 ## -remarks
 
 Direct color display modes do not use color lookup tables and are usually 16, 24, or 32 bit. Not all direct color video boards support loadable gamma ramps. <b>GetDeviceGammaRamp</b> succeeds only for devices with drivers that support downloadable gamma ramps in hardware.


### PR DESCRIPTION
I faced many issues, so many would have faced, that, the LPVOID is not actually required for storing the gamma values. The lpRamp variable can be a WORD Array of 3x256 elements. We can just pass the array into the function, and it will update it.
This example will save a lot of people's time and hardwork.